### PR TITLE
Expected attribute on <code>, and column+line information on errors

### DIFF
--- a/example.html
+++ b/example.html
@@ -8,7 +8,7 @@
 
 <script type="text/javascript">
   // uncomment next line to enable refresh
-  // PLT.refresh = true
+  PLT.refresh = true
 
   // write helper functions and semantics here
 </script>
@@ -41,8 +41,8 @@ Full documentation: http://pegjs.majda.cz/documentation#grammar-syntax-and-seman
 </grammar>
 
 <h3>Addition</h3>
-<code>(+ 5 10)</code>
-<code>(+7 13)</code>
+<code expect="15">(+ 5 10)</code>
+<code expect="20">(+7 13)</code>
 <code>(+ 7 13)</code>
 <code>(+ 7 13 )</code>
 <code>(+ 7 15 )</code>

--- a/js/plt.js
+++ b/js/plt.js
@@ -60,13 +60,37 @@ $(function() {
     try {
       var ast = PLT.parser.parse(goods[i].textContent);
       var str = JSON.stringify(ast);
+
+      // Look for expected attribute like this: <code expected="true">
+      if(goods[i].attributes.getNamedItem('expect')){
+        var expectedValue = goods[i].attributes.getNamedItem('expect').value;
+
+        // Validate that the expected value matches the returned value
+        if(expectedValue != str){
+          var error = new Error('Expected '+expectedValue+" but got "+str)
+          error.line = 0;
+          throw error; 
+        }
+      }
       // the code parsed, append result in grey
       goods[i].innerHTML += "\n<em style='color:gray'>&#8627; " + str + "</em>";
 
     } catch (err) {
       // the code did not parse, append result in red
-      goods[i].innerHTML += "\n<em style='color:red;'>&#8627; " + err.message + "</em>";
+      
+      // Add carrot to show the position of the error
+      var carrot = '';
+      if(err.line == goods[i].textContent.split('\n').length){
+        carrot = Array(err.column).join(' ')+'^\n'
+      }
 
+      // If there is line info, add information about where the error is
+      var lineError = '';
+      if(err.line){
+        lineError = "<br>\t" + "Line " + err.line + " Column "+err.column;
+      }
+
+      goods[i].innerHTML += "\n<em style='color:red;'>"+carrot+"&#8627; " + err.message + lineError + "</em>";
     }
   }
 


### PR DESCRIPTION
I added a attribute called `expected` on the `<code>` tag. Use it to express in the examples what value you expect, and if the value is not equal to the returned value, it will raise an error. This is useful for not only validating that the code is parsing, but that it is also parsing correctly. Use it like this 

```
<code expect="true"> true == false </code>
```

This would raise an error (except if the langue expects true to be equal to false of course) 

Also i added a carrot to show where on the line the parsing error was (if there was one on the last line). Was unsure where on the line the parser had a problem, and figured the information was in the error message. 
